### PR TITLE
fix: correct className bugs and invalid Tailwind arbitrary values

### DIFF
--- a/src/app/components/PageRowContent.jsx
+++ b/src/app/components/PageRowContent.jsx
@@ -5,10 +5,10 @@ import StatusBar from './StatusBar';
 export default function PageRowContent() {
   return (
     <div className="grid grid-cols-1 w-full md:grid-cols-2 md:pl-[17px] md:pr-[17px] lg:grid-cols-4 lg:pl-[68px] lg:pr-[50px] lg:pb-[0px] lg:mb-[0px] text-white">
-    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4  w-{97%} lg:w-{25%} lg:m-5 h-40 gap-10 rounded-lg bg-purple-800"} headerContent={"task completed"} numCompletedTasks={15} numTotalTasks={24} />
-    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4 w-{97%} lg:w-{25%} lg:m-5 h-40 gap-10 rounded-lg  bg-blue-400"} headerContent={"task completed"} numCompletedTasks={5} numTotalTasks={24} />
-    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4 w-{97%} lg:w-{25%} lg:m-5 h-40 gap-10 rounded-lg  bg-red-400"} headerContent={"task completed"} numCompletedTasks={20} numTotalTasks={24} />
-    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4 w-{97%} lg:w-{25%} lg:m-5 h-40 gap-10 rounded-lg  bg-blue-900"} headerContent={"task completed"} numCompletedTasks={5} numTotalTasks={24} />      
+    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4  w-[97%] lg:w-[25%] lg:m-5 h-40 gap-10 rounded-lg bg-purple-800"} headerContent={"task completed"} numCompletedTasks={15} numTotalTasks={24} />
+    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4 w-[97%] lg:w-[25%] lg:m-5 h-40 gap-10 rounded-lg  bg-blue-400"} headerContent={"task completed"} numCompletedTasks={5} numTotalTasks={24} />
+    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4 w-[97%] lg:w-[25%] lg:m-5 h-40 gap-10 rounded-lg  bg-red-400"} headerContent={"task completed"} numCompletedTasks={20} numTotalTasks={24} />
+    <StatusCard classname={"relative border border-gray-300 px-8 py-2 m-2 mb-4 w-[97%] lg:w-[25%] lg:m-5 h-40 gap-10 rounded-lg  bg-blue-900"} headerContent={"task completed"} numCompletedTasks={5} numTotalTasks={24} />      
     </div>
   )
 }

--- a/src/app/components/PageRowHeader.jsx
+++ b/src/app/components/PageRowHeader.jsx
@@ -4,32 +4,32 @@ import { FaHome } from 'react-icons/fa';
 
 export default function PageRowHeader() {
   return (
-  <div class="flex md:flex-row justify-between ">
+  <div className="flex md:flex-row justify-between ">
 
-      <div class="flex justify-center items-center md:justify-start md:w-1/2  p-3 md:px-8 lg:px-28">
+      <div className="flex justify-center items-center md:justify-start md:w-1/2  p-3 md:px-8 lg:px-28">
 
-          <h6 class="text-black text-2xl mb-0">Alternative</h6>
-          <nav class="hidden md:inline-block ml-4">
-              <ol class="flex flex-row items-center space-x-4 breadcrumb breadcrumb-links">
-                  <li class="breadcrumb-item">
-                      <a href="#" class="from-blue-500">
+          <h6 className="text-black text-2xl mb-0">Alternative</h6>
+          <nav className="hidden md:inline-block ml-4">
+              <ol className="flex flex-row items-center space-x-4 breadcrumb breadcrumb-links">
+                  <li className="breadcrumb-item">
+                      <a href="#" className="from-blue-500">
                           <FaHome />
                       </a>
                   </li>
-                  <li class="breadcrumb-item">
-                      <a href="#" class="from-blue-500">Dashboards</a>
+                  <li className="breadcrumb-item">
+                      <a href="#" className="from-blue-500">Dashboards</a>
                   </li>
-                  <li class="breadcrumb-item text-gray-700">Alternative</li>
+                  <li className="breadcrumb-item text-gray-700">Alternative</li>
               </ol>
           </nav>
 
       </div>
 
 
-      <div class="flex justify-center md:justify-end md:w-1/2  p-3 md:px-6 lg:px-20">
+      <div className="flex justify-center md:justify-end md:w-1/2  p-3 md:px-6 lg:px-20">
 
-          <a href="#" class="border border-gray-300 py-2 px-4 mr-2 bg-white shadow-lg hover:translate-y-0.5 transform transition">New</a>
-          <a href="#" class=" border border-gray-300 py-2 px-4 bg-white shadow-lg hover:translate-y-0.5 transform transition">Filter</a>
+          <a href="#" className="border border-gray-300 py-2 px-4 mr-2 bg-white shadow-lg hover:translate-y-0.5 transform transition">New</a>
+          <a href="#" className=" border border-gray-300 py-2 px-4 bg-white shadow-lg hover:translate-y-0.5 transform transition">Filter</a>
 
       </div>
 

--- a/src/app/components/StatusCard.jsx
+++ b/src/app/components/StatusCard.jsx
@@ -4,7 +4,7 @@ import StatusBar from './StatusBar';
 export default function StatusCard({headerContent, numCompletedTasks , numTotalTasks, bgColor, classname }) {
   return (
     <div className={classname}>
-      <button className="absolute right-4 top-4 text-black z-100 bg-white rounded px-2">...</button>
+      <button className="absolute right-4 top-4 text-black z-50 bg-white rounded px-2">...</button>
       <h4 className="my-2">{headerContent}</h4>
       <p className="my-3">{numCompletedTasks}/{numTotalTasks}</p>
       <StatusBar numTotalTasks={numTotalTasks} numCompletedTasks={numCompletedTasks} />


### PR DESCRIPTION
## What
Fixes rendering bugs from invalid className/Tailwind syntax that were
silently breaking styles.

## Changes
- `class` → `className` in PageRowHeader (JSX requires className)
- Fixed invalid Tailwind arbitrary value syntax (`w-{97%}` → `w-[97%]`)
- Fixed invalid `z-100` → `z-50`

## Why
Caught during a broader cleanup pass on the dashboard UI.